### PR TITLE
fix(filetype.vim): define a unique augroup name

### DIFF
--- a/filetype.vim
+++ b/filetype.vim
@@ -11,7 +11,7 @@ if !exists('g:chezmoi#source_dir_path')
   endif
 endif
 
-augroup filetypedetect
+augroup chezmoi_filetypedetect
   autocmd!
 
   execute 'autocmd BufNewFile,BufRead '. g:chezmoi#source_dir_path . '/* call chezmoi#filetype#handle_chezmoi_filetype()'


### PR DESCRIPTION
This addresses an issue where other Vim plugins, using the same autocommand group name, will remove the autocommands added by this Vim plugin. Using a more unique name fixes this.