### PR TITLE
Use `original_abs_path` from arg scope

### DIFF
--- a/autoload/chezmoi/filetype.vim
+++ b/autoload/chezmoi/filetype.vim
@@ -64,7 +64,7 @@ function! chezmoi#filetype#handle_chezmoitemplates_file(original_abs_path)
 
   if empty(&filetype)
     setlocal filetype=chezmoitmpl
-  elseif original_abs_path ==# without_tmpl
+  elseif a:original_abs_path ==# without_tmpl
     setlocal filetype+=.chezmoitmpl
   endif
 endfunction


### PR DESCRIPTION
It fixes #23 via using `original_abs_path` from argument scope (`a:`) instead of local scope (no prefix).