### PR TITLE
Ignore a `Quickfix` list

### DIFF
--- a/autoload/chezmoi/filetype.vim
+++ b/autoload/chezmoi/filetype.vim
@@ -6,7 +6,8 @@ set cpo-=l
 set cpo-=\
 
 function! chezmoi#filetype#handle_chezmoi_filetype() abort
-  if exists('b:chezmoi_handling') || exists('b:chezmoi_detecting_fixed')
+  if exists('b:chezmoi_handling') || exists('b:chezmoi_detecting_fixed') ||
+      \ &buftype ==# 'quickfix'
     return
   endif
   let b:chezmoi_handling = 1


### PR DESCRIPTION
Related: #68
This PR should fix it by ignoring a `Quickfix` list buffer.