### PR TITLE
Skip detection only for different buffers

### DIFF
--- a/autoload/chezmoi/filetype.vim
+++ b/autoload/chezmoi/filetype.vim
@@ -195,7 +195,7 @@ function! s:run_default_detect(detect_target) abort
   let b:chezmoi_detecting_fixed = 1
 
   let bufnr_org = bufnr()
-  if bufexists(a:detect_target)
+  if bufexists(a:detect_target) && bufnr(a:detect_target) != bufnr_org
     " Copy filetype to original buffer from an existant buffer.
     call setbufvar(bufnr_org, '&filetype', getbufvar(a:detect_target, '&filetype'))
   elseif exists('g:chezmoi#use_tmp_buffer') && g:chezmoi#use_tmp_buffer == v:true


### PR DESCRIPTION
Fixes #85

Currently, when a buffer with the same name already exists, the default filetype detection is skipped and the filetype is copied from that existing buffer.

In the `.chezmoitemplates/` directory, files without the `.tmpl` suffix are also treated as template files, so the edited file path and the detection target file path become identical. In this case, the current implementation incorrectly identifies the buffer of the edited file itself as an "existing buffer with the same name".

This fix ensures that default detection is skipped only when the buffer number of the detection target file path differs from the buffer number of the edited file.

Note: It's unclear why this issue doesn't occur on WSL.
