### PR TITLE
fix(detecting): Skip detection only for differect buffers

### DIFF
--- a/autoload/chezmoi/filetype.vim
+++ b/autoload/chezmoi/filetype.vim
@@ -196,8 +196,14 @@ function! s:run_default_detect(detect_target) abort
 
   let bufnr_org = bufnr()
   if bufexists(a:detect_target)
-    " Copy filetype to original buffer from an existant buffer.
-    call setbufvar(bufnr_org, '&filetype', getbufvar(a:detect_target, '&filetype'))
+    if (bufnr(a:detect_target) == bufnr_org)
+      " For non-chezmoi-template files and chezmoi-template files without
+      " `.tmpl` suffix, the file's own path is used as the detection target.
+      execute 'doau filetypedetect BufRead ' . fnameescape(a:detect_target)
+    else
+      " Copy filetype to original buffer from an existant buffer.
+      call setbufvar(bufnr_org, '&filetype', getbufvar(a:detect_target, '&filetype'))
+    endif
   elseif exists('g:chezmoi#use_tmp_buffer') && g:chezmoi#use_tmp_buffer == v:true
     " Save current status.
     let evignore_save = &eventignore


### PR DESCRIPTION
This is a fixed version of PR #86 (which attempted to fix #85 but introduced a new bug #87).

Description copied from #86:

> Currently, when a buffer with the same name already exists, the default filetype detection is skipped and the filetype is copied from that existing buffer.
>
> In the `.chezmoitemplates/` directory, files without the `.tmpl` suffix are also treated as template files, so the edited file path and the detection target file path become identical. In this case, the current implementation incorrectly identifies the buffer of the edited file itself as an "existing buffer with the same name".
>
> This fix ensures that default detection is skipped only when the buffer number of the detection target file path differs from the buffer number of the edited file.

This PR takes a different approach from #86. Instead of combining the buffer number comparison with existing conditions using AND operations (to minimize branching), this PR uses nested branches to ensure the existing conditional behavior is not affected.

Fixes #85
Fixes #87