### PR TITLE
docs(README): Clarify scope, add requirements and plugin-manager guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 <h1><strong>chezmoi.vim</strong></h1>
 
-<strong>This plugin adds the support for your editing dotfiles in <a href="https://github.com/twpayne/chezmoi">chezmoi</a> source path.</strong>
+<strong>This plugin adds support for editing your dotfiles in a <a href="https://github.com/twpayne/chezmoi">chezmoi</a> source directory.</strong>
 </div>
 
 <br>
 
-<div align="center"><p>Highlight even a template file</p>
+<div align="center"><p>Highlighting even a template file</p>
 <img src="https://user-images.githubusercontent.com/51204827/147376940-f9c23c25-89da-4ad0-9b92-907266afa388.gif" alt="highlighting a template demo" height="400px">
 
 </div>
@@ -15,6 +15,7 @@
 
 - [Why](#why)
 - [Features](#features)
+- [Requirements](#requirements)
 - [Install](#install)
 - [Usage](#usage)
 - [Options](#options)
@@ -24,42 +25,111 @@
 
 # Why
 
-[chezmoi](https://github.com/twpayne/chezmoi) makes it much easier for you to manage your dotfiles. `chezmoi` uses special file naming (e.g. `dot_bashrc`) but you get still a syntax highlighting support because `chezmoi edit` resolves special naming before passing files to your editor. However you miss a correct highlighting in the following cases:
-- When you edit directly dotfiles without `chezmoi edit`, `vim` does not highlight it.
-- If you use [template](https://www.chezmoi.io/user-guide/templating) files (the powerful feature of `chezmoi`), `vim` losses an original syntax highlighting
+[chezmoi](https://github.com/twpayne/chezmoi) makes it much easier to manage your dotfiles. `chezmoi` uses special file naming (e.g. `dot_bashrc`), but you still get syntax highlighting support because `chezmoi edit` resolves the special naming before passing files to your editor. However, you lose correct highlighting in the following cases:
+- When you edit dotfiles directly without `chezmoi edit`, `vim` does not highlight them.
+- If you use [template](https://www.chezmoi.io/user-guide/templating) files (the powerful feature of `chezmoi`), `vim` loses the original syntax highlighting.
 
 This plugin solves those problems.
 
 # Features
 
-This plugin makes vim treat the files to be edited as follows:
+This plugin makes `vim` treat the files you edit as their resolved targets, for example:
 * `dot_bashrc` => `.bashrc`
 * `dot_config/git/private_config` => `.config/git/config`
 
-Furthermore, **with keeping original highlighting**, this plugin applies that of `go-template` to template files (e.g. `dot_vimrc.tmpl`), as shown in the demo image.
+Furthermore, **while keeping the original highlighting**, this plugin layers `go-template` highlighting on top of template files (e.g. `dot_vimrc.tmpl`), as shown in the demo image.
+
+Beyond plain source files, it also recognises chezmoi's special files and applies the right highlighting. A representative subset:
+
+| Kind | Examples |
+| --- | --- |
+| Attribute prefixes | `private_`, `executable_`, `readonly_`, `encrypted_`, `literal_`, … (e.g. `private_dot_netrc` => `.netrc`) |
+| Templates | any `*.tmpl` file, and everything under `.chezmoitemplates/` (base filetype **+** `chezmoitmpl`) |
+| Config & data | `.chezmoi.<ext>.tmpl`, `.chezmoidata.<ext>`, files under `.chezmoidata/` |
+| Externals | `.chezmoiexternal.<ext>`, files under `.chezmoiexternals/` |
+| Ignore lists | `.chezmoiignore`, `.chezmoiremove` |
+
+This is not an exhaustive list; the goal is to cover chezmoi's common naming conventions while keeping editing as seamless as possible.
+
+# Requirements
+
+* **Vim 8.2.2449 or later**, or **Neovim 0.6.0 or later**.
+
+  The plugin relies on a few relatively recent built-in functions — most notably `flatten()` (Vim 8.2.2449 / Neovim 0.6.0) and the `{dir}` argument of `trim()` (Vim 8.2.1042) — so earlier versions are not supported.
+
+* **Platforms.** The plugin is developed and tested on Unix-like systems and works there as the primary target. It is *expected* to work on Windows as well — including native Windows, WSL, Git Bash and MSYS2 — but those environments, together with the various plugin managers and the `chezmoi` binary itself, can behave subtly differently. Testing every combination is impractical, so Windows is supported on a best-effort basis **without guarantees**. (In particular, the hardlink-based `chezmoi edit` detection described in [Usage](#usage) is currently enabled on Unix only.)
 
 # Install
 
-:warning: You must load this plugin before the following timings:
+:warning: You must load this plugin before any of the following:
 * Calling `filetype on`, `syntax enable` or `syntax on`
 * Loading other plugins that include `filetype.vim`
-* End of `vimrc`
-* End of `init.vim` if you use neovim
+* The end of your `vimrc`
+* The end of your `init.vim` if you use Neovim
 
-However enabling the `g:chezmoi#use_tmp_buffer` experimental option makes you free from the above limitation (see the [Options section](#options) for more details).
+However, enabling the experimental `g:chezmoi#use_tmp_buffer` option frees you from the limitation above (see the [Options section](#options) for more details).
 
-If you use [Vim 8 packages](http://vimhelp.appspot.com/repeat.txt.html#packages):
+You must **not** load this plugin lazily; otherwise filetype detection will not work correctly. Unless you enable `g:chezmoi#use_tmp_buffer`, you must also load `chezmoi.vim` earlier than other plugins.
+
+The [FAQ section](#faq) can help with some installation cases. If `chezmoi.vim` doesn't work for you, check there first.
+
+### [Vim 8 packages](http://vimhelp.appspot.com/repeat.txt.html#packages)
+
 ```sh
 $ git clone https://github.com/alker0/chezmoi.vim ~/.vim/pack/plugins/opt/chezmoi.vim
 ```
-And then insert this line your `vimrc` with taking the above notes into consideration:
+Then add this line to your `vimrc`, keeping the notes above in mind:
 ```vim
 packadd chezmoi.vim
 ```
 
-You can also use the favorite plugin manager but you must **not** load this plugin lazily for detecting filetype correctly. You also have to load `chezmoi.vim` earlier than others unless you enable the `g:chezmoi#use_tmp_buffer` option.
+### [vim-plug](https://github.com/junegunn/vim-plug)
 
-The [FAQ section](#faq) can help you to install in some case. If `chezmoi.vim` don't work for you, see there at first.
+List `chezmoi.vim` first so it loads before the other plugins, and do **not** add any lazy-loading keys (`on`, `for`):
+```vim
+call plug#begin()
+Plug 'alker0/chezmoi.vim'
+" ...other plugins
+call plug#end()
+```
+
+### [dein.vim](https://github.com/Shougo/dein.vim)
+
+```vim
+call dein#add('alker0/chezmoi.vim')
+```
+Do **not** set `lazy`, `on_ft` or similar options. Because dein merges plugins and the load order is hard to control, enabling `g:chezmoi#use_tmp_buffer` (see below) is recommended.
+
+### [mini.deps](https://github.com/echasnovski/mini.deps)
+
+Set the required option and add the plugin inside `now()` so it is sourced during startup:
+```lua
+local add, now = MiniDeps.add, MiniDeps.now
+now(function()
+  -- This option is required.
+  vim.g['chezmoi#use_tmp_buffer'] = true
+  add('alker0/chezmoi.vim')
+end)
+```
+
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+See the [FAQ](#faq-2).
+
+### [packer.nvim](https://github.com/wbthomason/packer.nvim) / [pckr.nvim](https://github.com/lewis6991/pckr.nvim)
+
+`packer.nvim` is unmaintained; its successor is `pckr.nvim`. The declaration is the same for both. Set the required option in `setup`, which runs before the plugin loads:
+```lua
+use {
+  'alker0/chezmoi.vim',
+  setup = function()
+    -- This option is required.
+    vim.g['chezmoi#use_tmp_buffer'] = true
+  end,
+}
+```
+
+> **Tip for Neovim plugin managers:** enabling `g:chezmoi#use_tmp_buffer` is the simplest way to avoid every load-ordering problem, because it removes the requirement to load `chezmoi.vim` before other plugins.
 
 # Usage
 
@@ -70,7 +140,7 @@ $ chezmoi edit ~/.bashrc
 $ chezmoi cd
 $ vim dot_bashrc
 ```
-This plugin resolves the special prefixes automatically therefore highlighting for bash is applied correctly.
+This plugin resolves the special prefixes automatically, so bash highlighting is applied correctly.
 
 If the file is a chezmoi template, this plugin merges syntax highlighting as follows:
 * `dot_vimrc.tmpl` => `vim` + `go-template`
@@ -80,14 +150,19 @@ If the file is a chezmoi template, this plugin merges syntax highlighting as fol
 | Flag                              | Default                                                  | Description                                            |
 | --------------------------------- | -------------------------------------------------------- | ----------------------------------------------         |
 | `g:chezmoi#_loaded`               | 0                                                        | Setting 1 before loading disables this plugin          |
-| `g:chezmoi#detect_ignore_pattern` | \<empty string>                                          | Regex pattern of path for ignoring file type detection |
-| `g:chezmoi#use_external`          | \<not set>                                               | If set, enables the use of the external chezmoi binary for various purposes. More advanced, but slower. See comments below for more details |
-| `g:chezmoi#source_dir_path`       | The value returned by `chezmoi source-path` (if the use of external chezmoi is enabled) or `$XDG_DATA_HOME/chezmoi` or `$HOME/.local/share/chezmoi` | Source Directory managed by chezmoi |
-| `g:chezmoi#use_tmp_buffer`        | 0 | (experimental) Setting 1 makes this plugin create and use temporary buffer for making builtin filetype detection override wrong filetype |
+| `g:chezmoi#detect_ignore_pattern` | \<empty string>                                          | Regex pattern; paths matching it are skipped during filetype detection (see the note below) |
+| `g:chezmoi#use_external`          | \<not set>                                               | If set, enables the use of the external chezmoi binary for various purposes. More advanced, but slower. See the notes below for more details |
+| `g:chezmoi#source_dir_path`       | The value returned by `chezmoi source-path` (if the use of external chezmoi is enabled) or `$XDG_DATA_HOME/chezmoi` or `$HOME/.local/share/chezmoi` | Source directory managed by chezmoi |
+| `g:chezmoi#use_tmp_buffer`        | 0 | (experimental) Setting 1 makes this plugin create and use a temporary buffer so that builtin filetype detection can override a wrong filetype |
 
 Note:
-* To enable the use of the external chezmoi binary, set the `g:chezmoi#use_external` variable. This variable must be set in `.vimrc` file, before the plugin is sourced. The value must be either a valid path to the binary, or just the binary name, if it can be found in `$PATH`. Alternatively, the value can be set to 1, in which case the plugin will try to detect the binary name automatically. After the plugin is sourced, the value of this variable may change. It will contain either the full name of the chezmoi binary that is used, or empty if the external chezmoi can not be used for some reason.
-* If you get some problem about ordering of filetype detection, try setting the `g:chezmoi#use_tmp_buffer` variable with `1`. The feature should make it working correctly with any ordering, via using temporary buffer for avoiding limitation of Vim/Neovim's builtin filetype detection. The builtin detection use `setfiletype` ex command that works only once per buffer, so if using only same buffer (that is current default behavior of this plugin), asking Vim to run builtin detection with resolved path works only before calling `setfiletype` with wrong filetype. But if this plugin creates and uses a new temporary buffer every detection, `setfiletype` works again so this plugin can get resolved filetype from builtin detection anytime.
+* `g:chezmoi#detect_ignore_pattern` is an intentional **escape hatch**. The files this plugin hooks into live in your dotfiles repository, which may contain sensitive information, so a misdetection or misbehaviour could cause a serious incident. This option lets you turn detection off for arbitrary paths at any time — keep it in mind as a safety valve if the plugin ever interferes with a file you care about. For example:
+  ```vim
+  " Skip detection for everything under a particular subtree.
+  let g:chezmoi#detect_ignore_pattern = '/secret/'
+  ```
+* To enable the use of the external chezmoi binary, set the `g:chezmoi#use_external` variable. This variable must be set in your `.vimrc` file, before the plugin is sourced. The value must be either a valid path to the binary, or just the binary name if it can be found in `$PATH`. Alternatively, the value can be set to 1, in which case the plugin will try to detect the binary name automatically. After the plugin is sourced, the value of this variable may change. It will contain either the full name of the chezmoi binary that is used, or empty if the external chezmoi cannot be used for some reason.
+* If you have a problem with the ordering of filetype detection, try setting the `g:chezmoi#use_tmp_buffer` variable to `1`. This feature should make it work correctly with any ordering, by using a temporary buffer to avoid a limitation of Vim/Neovim's builtin filetype detection. The builtin detection uses the `setfiletype` ex command, which works only once per buffer; so if only the same buffer is used (the current default behaviour of this plugin), asking Vim to run builtin detection with the resolved path works only before `setfiletype` is called with a wrong filetype. But if this plugin creates and uses a new temporary buffer for every detection, `setfiletype` works again, so this plugin can get the resolved filetype from builtin detection at any time.
 
 # FAQ
 
@@ -97,25 +172,25 @@ Note:
 
 ### <a id="faq-1"></a> How can I make it work even if my chezmoi source directory isn't the default path?
 
-Specify `g:chezmoi#source_dir_path` with your source directory path for let the plugin know like this:
+Set `g:chezmoi#source_dir_path` to your source directory path to let the plugin know, like this:
 ```vim
 let g:chezmoi#source_dir_path = '/path/to/your/source/dir'
-" or if your `vimrc` is `chezmoi-template`:
+" or if your `vimrc` is a `chezmoi-template`:
 let g:chezmoi#source_dir_path = '{{ .chezmoi.sourceDir }}'
 ```
 
-For tracking your changing source directory with the `chezmoi` config (e.g. `~/.config/chezmoi/chezmoi.config.toml`) even without synchronizing there with calling like `chezmoi apply`, you can enable `g:chezmoi#use_external` instead of the above. It makes the plugin get your source directory path by calling `chezmoi source-path` command but it can have a little performance cost. For example:
+To keep up with a source directory that you change through the `chezmoi` config (e.g. `~/.config/chezmoi/chezmoi.config.toml`) — even without synchronising it via a command like `chezmoi apply` — you can enable `g:chezmoi#use_external` instead of the above. It makes the plugin obtain your source directory path by calling the `chezmoi source-path` command, at a small performance cost. For example:
 ```vim
 let g:chezmoi#use_external = 1
 " or if your `chezmoi` binary isn't in your `$PATH` environment variable:
 let g:chezmoi#use_external = '/path/to/your/chezmoi/binary'
-" or if your `vimrc` is `chezmoi-template`:
+" or if your `vimrc` is a `chezmoi-template`:
 let g:chezmoi#use_external = '{{ .chezmoi.executable }}'
 ```
 
 ### <a id="faq-2"></a> How can I make it work with `lazy.nvim`?
 
-Add the plugin like this minimum example:
+Add the plugin like this minimal example:
 ```lua
 require('lazy').setup({
   -- ...other plugins
@@ -134,17 +209,17 @@ require('lazy').setup({
 })
 ```
 
-Because the `g:chezmoi#use_tmp_buffer` option is required, you can insert `chezmoi.vim` anywhere without caring a ordering of plugins.
+Because the `g:chezmoi#use_tmp_buffer` option is required here, you can place `chezmoi.vim` anywhere without worrying about plugin ordering.
 
 ### <a id="faq-3"></a> Can I use `nvim-treesitter` for my `chezmoi-template`?
 
-No, the plugin supports for `treesitter` only detecting filetype and highlighting your non-`chezmoi-template` file. When you edit a `chezmoi-template` file, you have to disable `treesitter` and have Vim builtin highlighting with support from `chezmoi.vim`.
+No. For `treesitter`, the plugin only supports filetype detection and highlighting of your non-`chezmoi-template` files. When you edit a `chezmoi-template` file, you have to disable `treesitter` and rely on Vim's builtin highlighting together with the support from `chezmoi.vim`.
 
 ```lua
 require('nvim-treesitter.configs').setup({
   highlight = {
     disable = function()
-      -- check if 'filetype' option includes 'chezmoitmpl'
+      -- check if the 'filetype' option includes 'chezmoitmpl'
       if string.find(vim.bo.filetype, 'chezmoitmpl') then
         return true
       end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 # Table of contents
 
-- [Why](#why)
+- [Motivation](#motivation)
 - [Features](#features)
 - [Requirements](#requirements)
 - [Install](#install)
@@ -23,7 +23,7 @@
 - [Contributing](#contributing)
 - [License](#license)
 
-# Why
+# Motivation
 
 [chezmoi](https://github.com/twpayne/chezmoi) makes it much easier to manage your dotfiles. `chezmoi` uses special file naming (e.g. `dot_bashrc`), but you still get syntax highlighting support because `chezmoi edit` resolves the special naming before passing files to your editor. However, you lose correct highlighting in the following cases:
 - When you edit dotfiles directly without `chezmoi edit`, `vim` does not highlight them.
@@ -57,15 +57,17 @@ This is not an exhaustive list; the goal is to cover chezmoi's common naming con
 
   The plugin relies on a few relatively recent built-in functions — most notably `flatten()` (Vim 8.2.2449 / Neovim 0.6.0) and the `{dir}` argument of `trim()` (Vim 8.2.1042) — so earlier versions are not supported.
 
-* **Platforms.** The plugin is developed and tested on Unix-like systems and works there as the primary target. It is *expected* to work on Windows as well — including native Windows, WSL, Git Bash and MSYS2 — but those environments, together with the various plugin managers and the `chezmoi` binary itself, can behave subtly differently. Testing every combination is impractical, so Windows is supported on a best-effort basis **without guarantees**. (In particular, the hardlink-based `chezmoi edit` detection described in [Usage](#usage) is currently enabled on Unix only.)
+> [!NOTE]
+> **Platforms.** The plugin is developed and tested on Unix-like systems and works there as the primary target. It is *expected* to work on Windows as well — including native Windows, WSL, Git Bash and MSYS2 — but those environments, together with the various plugin managers and the `chezmoi` binary itself, can behave subtly differently. Testing every combination is impractical, so Windows is supported on a best-effort basis **without guarantees**. (In particular, the hardlink-based `chezmoi edit` detection described in [Usage](#usage) is currently enabled on Unix only.)
 
 # Install
 
-:warning: You must load this plugin before any of the following:
-* Calling `filetype on`, `syntax enable` or `syntax on`
-* Loading other plugins that include `filetype.vim`
-* The end of your `vimrc`
-* The end of your `init.vim` if you use Neovim
+> [!WARNING]
+> You must load this plugin before any of the following:
+> * Calling `filetype on`, `syntax enable` or `syntax on`
+> * Loading other plugins that include `filetype.vim`
+> * The end of your `vimrc`
+> * The end of your `init.vim` if you use Neovim
 
 However, enabling the experimental `g:chezmoi#use_tmp_buffer` option frees you from the limitation above (see the [Options section](#options) for more details).
 
@@ -129,7 +131,8 @@ use {
 }
 ```
 
-> **Tip for Neovim plugin managers:** enabling `g:chezmoi#use_tmp_buffer` is the simplest way to avoid every load-ordering problem, because it removes the requirement to load `chezmoi.vim` before other plugins.
+> [!TIP]
+> For Neovim plugin managers, enabling `g:chezmoi#use_tmp_buffer` is the simplest way to avoid every load-ordering problem, because it removes the requirement to load `chezmoi.vim` before other plugins.
 
 # Usage
 


### PR DESCRIPTION
- Add a Requirements section documenting the minimum editor versions
  (Vim 8.2.2449+ / Neovim 0.6.0+, driven by flatten() and trim()'s {dir}
  argument) and the best-effort, untested-but-expected Windows support.
- Expand Features with a representative table of supported chezmoi special
  files (templates, config/data, externals, ignore lists) without listing
  everything.
- Add install examples for vim-plug, dein.vim, mini.deps and packer/pckr,
  emphasising the no-lazy-load and ordering constraints.
- Explain g:chezmoi#detect_ignore_pattern as a safety escape hatch.
- Fix unnatural English throughout.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>