### PR TITLE
docs: Move low-level version rationale out of README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,31 @@ submit it.
 
 ---
 
+## Editor compatibility
+
+The plugin targets **Vim 8.2.2449+** and **Neovim 0.6.0+**. This baseline is a
+deliberate trade-off, not an accident — the plugin intentionally avoids some
+newer conveniences (for example, it works around `++once`, added in Vim
+8.1.1113, with an `augroup`) to keep the floor as low as is practical.
+
+Today that floor is set by two built-ins:
+
+| Built-in | Introduced | Used in |
+| --- | --- | --- |
+| `trim({text}, {mask}, {dir})` — the third `{dir}` argument | Vim 8.2.1042 | `filetype.vim` (stripping trailing path delimiters / CR-LF) |
+| `flatten()` | Vim 8.2.2449 / Neovim 0.6.0 | `syntax/chezmoitmpl.vim` (combining keyword lists) |
+
+When contributing to the core or syntax files, please:
+
+- **Avoid raising the floor** without a clear reason. Prefer functions and
+  syntax that already work on the versions above. If a change genuinely needs a
+  newer built-in, call it out in the PR so the requirement can be discussed and
+  the README/`filetype.vim` note updated together.
+- **Lowering the floor is welcome** if it is clean. Both built-ins above can be
+  replaced (e.g. `trim(..., {dir})` with a `substitute()`, `flatten()` with
+  `split()`/`map()`); if you do this, update the comment in `filetype.vim` and
+  the requirement in the README to match.
+
 ## Updating `syntax/chezmoitmpl.vim`
 
 `syntax/chezmoitmpl.vim` highlights chezmoi's own template functions on top of

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ This is not an exhaustive list; the goal is to cover chezmoi's common naming con
 
 # Requirements
 
-* **Vim 8.2.2449 or later**, or **Neovim 0.6.0 or later**.
-
-  The plugin relies on a few relatively recent built-in functions — most notably `flatten()` (Vim 8.2.2449 / Neovim 0.6.0) and the `{dir}` argument of `trim()` (Vim 8.2.1042) — so earlier versions are not supported.
+* **Vim 8.2.2449 or later**, or **Neovim 0.6.0 or later.** Earlier versions lack some built-in functions the plugin depends on.
 
 > [!NOTE]
 > **Platforms.** Unix-like systems are the primary, tested target. Windows (native, WSL, Git Bash, MSYS2) is *expected* to work, but is supported on a best-effort basis **without guarantees** — see [the FAQ](#faq-4) for why. (The hardlink-based `chezmoi edit` detection is currently enabled on Unix only.)

--- a/filetype.vim
+++ b/filetype.vim
@@ -1,3 +1,11 @@
+" Minimum supported versions: Vim 8.2.2449+ / Neovim 0.6.0+.
+" Two built-ins set this floor:
+"   - trim()'s third {dir} argument (Vim 8.2.1042), used throughout this file
+"     to strip trailing path delimiters / CR-LF.
+"   - flatten() (Vim 8.2.2449 / Neovim 0.6.0), used in syntax/chezmoitmpl.vim.
+" If you ever need to lower the floor, both can be replaced (e.g. trim with a
+" substitute(), flatten with split()+map()); keep this note in sync.
+
 if exists('g:chezmoi#_loaded')
   finish
 endif

--- a/syntax/chezmoitmpl.vim
+++ b/syntax/chezmoitmpl.vim
@@ -150,7 +150,9 @@ unlet! b:current_syntax
 
 source <sfile>:h/gotmpl.vim
 
-" Combine all keywords in one line
+" Combine all keywords in one line.
+" flatten() requires Vim 8.2.2449+ / Neovim 0.6.0+ (the plugin's minimum
+" supported versions; see the note in filetype.vim).
 let s:chezmoiTmplFunctionsCombined = flatten([
   \ s:onepasswordKeywords,
   \ s:awsKeywords,


### PR DESCRIPTION
## Summary

Relocate the low-level version rationale out of the user-facing README.

The README's *Requirements* section previously named the specific built-ins behind the minimum version. That detail is too low-level for most users, so the README now states only the supported versions (**Vim 8.2.2449+ / Neovim 0.6.0+**). The concrete incompatibility factors are recorded where they actually matter:

- **`README.md`** — removed the internal function-name references; keeps just the version requirement.
- **`filetype.vim` / `syntax/chezmoitmpl.vim`** — code comments at the relevant sites explaining the version floor.
- **`CONTRIBUTING.md`** — a new *Editor compatibility* section documenting the baseline, why it is what it is (e.g. the `++once` workaround), and a contributor policy for raising/lowering the floor.

For the record, the floor is currently set by two built-ins:
- `trim()`'s third `{dir}` argument (Vim 8.2.1042), used throughout `filetype.vim`.
- `flatten()` (Vim 8.2.2449 / Neovim 0.6.0), used in `syntax/chezmoitmpl.vim`.

## Testing

Docs/comments-only change; no behavioural change to the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011x6drJAFa7rn3R3Aig8fTL)_