### PR TITLE
Omit session URL from commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "sessionUrl": ""
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
Add `attribution.sessionUrl` for make Claude Code no longer append the session URL to generated commit messages and pull request descriptions.

<!--
Thanks for contributing! Please read CONTRIBUTING.md before opening this PR,
especially the AI-assisted contributions policy.
-->

## Summary

<!-- What does this change do, and why? -->

## AI usage

Claude Code generate only the commit message.

<!--
If any part of this PR was generated or materially assisted by an AI tool,
state the tool(s) and the scope (which files/parts). Write "None" if no AI
was used. See CONTRIBUTING.md §2.
Example: "Claude Code generated the keyword list in syntax/chezmoitmpl.vim;
the rest is hand-written."
-->

## Verification

<!-- Which Vim/Neovim versions and which files/paths did you test? -->

Since the behavior hasn't changed, testing is not necessary.

## Checklist

- [x] I understand every line I am submitting and can explain it.
- [ ] I tested the change in **both Vim and Neovim** (noted above).
- [x] If I used an AI tool, I disclosed the tool and the scope of its use.
- [x] I did not modify `vendor/`.
- [x] Any AI-assisted code is not a verbatim copy of third-party work and is MIT-compatible.
